### PR TITLE
Added "cancels &&" guard against error that cropped up on line 506 in…

### DIFF
--- a/rq.js
+++ b/rq.js
@@ -503,7 +503,7 @@ var RQ = (function () {
                             },
                             initial
                         );
-                        if (cancels[index] === undefined) {
+                        if (cancels && cancels[index] === undefined) {
                             cancels[index] = cancellation;
                         }
                     });


### PR DESCRIPTION
this change makes line 506 the same as line 393 in RQ.parallel()

``` if (cancels && cancels[index] === undefined) {```

The error received was:
```"Unable to get property '0' of undefined or null reference"```
 at line 506 in RQ.race()



Line 472: was found to be what was resetting cancels=[]
``` "cancels = undefined;"``` 

Note: this change may not be needed since I changed 2 things to make RQ work in my context 
1. using a setImmediate() polyfil and 2. Using for(x in y){} ES3, instead of Array.forEach()